### PR TITLE
Pages table detail heading refactor

### DIFF
--- a/frontend/src/components/sharedStyles/Table/CreateTablesStyle.js
+++ b/frontend/src/components/sharedStyles/Table/CreateTablesStyle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import {
     Link as StyledLink,
-    Table, TableBody, TableCell, TableHead, TableRow, Typography, 
+    Table, TableBody, TableCell, TableHead, TableRow,
   } from '@material-ui/core';
 
 
@@ -10,12 +10,6 @@ import {
 function CreateGradeTable(props) {
     return (
         <div>
-        <Typography
-          variant="h4"
-          component="h1"
-          className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>
@@ -69,12 +63,6 @@ function CreateGradeTable(props) {
 function CreateStudentTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                   <TableRow>
@@ -118,19 +106,13 @@ function CreateStudentTable(props) {
 function CreateAttendanceTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>
                 <TableCell className={props.tHead}>Student</TableCell>
                 <TableCell className={props.tHead}>Entry Date</TableCell>
-                <TableCell className={props.tHead}>Total Unexcused Absencse</TableCell>
-                <TableCell className={props.tHead}>Total Excused Absencse</TableCell>
+                <TableCell className={props.tHead}>Total Unexcused Absence</TableCell>
+                <TableCell className={props.tHead}>Total Excused Absence</TableCell>
                 <TableCell className={props.tHead}>Total Tardies</TableCell>
                 <TableCell className={props.tHead}>Average Daily Attendance</TableCell>
                 <TableCell className={props.tHead}>Final</TableCell>
@@ -177,12 +159,6 @@ function CreateAttendanceTable(props) {
 function CreateCourseTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>
@@ -231,12 +207,6 @@ function CreateCourseTable(props) {
 function CreateDistrictTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>
@@ -280,12 +250,6 @@ function CreateDistrictTable(props) {
 function CreateProgramTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>
@@ -320,12 +284,6 @@ function CreateProgramTable(props) {
 function CreateSchoolTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>
@@ -371,12 +329,6 @@ function CreateSchoolTable(props) {
 function CreateBehaviorTable(props) {
     return (
         <div>
-        <Typography
-            variant="h4"
-            component="h1"
-            className={props.header}
-        >{props.title}
-        </Typography>
         <Table>
             <TableHead>
                 <TableRow>

--- a/frontend/src/components/sharedStyles/Table/TableHeader.js
+++ b/frontend/src/components/sharedStyles/Table/TableHeader.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {
+    Typography, 
+  } from '@material-ui/core';
+
+
+function CreateTableHeader(props) {
+    return(
+        <Typography
+        variant="h4"
+        component="h1"
+        className={props.headerClassStyle}
+        >{props.title}
+        </Typography>
+    );
+}
+
+export default CreateTableHeader;

--- a/frontend/src/components/sharedStyles/Table/TablePageStyles.js
+++ b/frontend/src/components/sharedStyles/Table/TablePageStyles.js
@@ -6,6 +6,13 @@ const TablePageStyles = theme => ({
       marginBottom: theme.spacing.unit * 1,
       textTransform: 'uppercase',
     },
+    tableTitle: {
+      color: theme.palette.primary.main,
+      fontWeight: 800,
+      minWidth: 120,
+      fontSize: 16,
+
+    },
     striped: {
       background: theme.grays.g0,
     },

--- a/frontend/src/pages/Table/Course/CourseDetail.js
+++ b/frontend/src/pages/Table/Course/CourseDetail.js
@@ -8,6 +8,7 @@ import { DetailLink, DetailItem} from 'components/sharedStyles/Table/DetailStyle
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateGradeTable, CreateStudentTable, CreateAttendanceTable } from 'components/sharedStyles/Table/CreateTablesStyle';
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
 
 
 
@@ -54,15 +55,28 @@ function CourseDetail(props) {
           <DetailItem k="Subject" val={courseSubject} />
           <DetailLink k="School" val={schoolName} link={`/school/${schoolId}`} />
 
-          < CreateGradeTable header = {header} title = "Grades"
-          tHead = {tHead} data = {gradeSet} tRow = {tRow} 
-          striped = {striped} />
 
-          < CreateAttendanceTable header = {header} title = "Attendance"
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Grades" />
+          < CreateGradeTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {gradeSet} 
+            tRow = {tRow} 
+            striped = {striped} />
+
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Attendance" />
+          < CreateAttendanceTable header = {header} 
           tHead = {tHead} data = {attendanceSet} tRow = {tRow} 
           striped = {striped} />
 
-          < CreateStudentTable header = {header} title = "Student"
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Student" />
+          < CreateStudentTable header = {header} 
           tHead = {tHead} data = {studentSet} tRow = {tRow} 
           striped = {striped} />
 

--- a/frontend/src/pages/Table/Course/Courses.js
+++ b/frontend/src/pages/Table/Course/Courses.js
@@ -9,6 +9,8 @@ import {
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateCourseTable } from 'components/sharedStyles/Table/CreateTablesStyle';
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
+
 
 
 function Courses(props) {
@@ -34,9 +36,17 @@ function Courses(props) {
   }
 
   return (
-    < CreateCourseTable header = {header} title = 'All Courses'
-    tHead = {tHead} data = {courses} tRow = {tRow} 
-    striped = {striped} />
+    <div>
+      <CreateTableHeader
+        headerClassStyle = {header}
+        title = "All Courses" />
+      < CreateCourseTable 
+        header = {header} 
+        tHead = {tHead} 
+        data = {courses} 
+        tRow = {tRow} 
+        striped = {striped} />
+    </div>
   );
 }
 

--- a/frontend/src/pages/Table/District/DistrictDetail.js
+++ b/frontend/src/pages/Table/District/DistrictDetail.js
@@ -9,7 +9,7 @@ import {  DetailItem} from 'components/sharedStyles/Table/DetailStyles';
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateSchoolTable } from 'components/sharedStyles/Table/CreateTablesStyle';
-
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
 
 
 
@@ -52,9 +52,16 @@ function DistrictDetail(props) {
           <DetailItem k="City" val={city} />
           <DetailItem k="State" val={state} />
 
-          < CreateSchoolTable header = {header} title = "School"
-          tHead = {tHead} data = {schoolSet} tRow = {tRow} 
-          striped = {striped} />
+
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "School" />
+          < CreateSchoolTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {schoolSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
       </div>
   );

--- a/frontend/src/pages/Table/District/Districts.js
+++ b/frontend/src/pages/Table/District/Districts.js
@@ -8,6 +8,8 @@ import { withStyles,
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateDistrictTable } from 'components/sharedStyles/Table/CreateTablesStyle';
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
+
 
 
 function Districts(props) {
@@ -34,9 +36,17 @@ function Districts(props) {
 
 
   return (
-    < CreateDistrictTable header = {header} title = 'All District' 
-    tHead = {tHead} data = {districts} tRow = {tRow} 
-    striped = {striped} />
+    <div>
+      <CreateTableHeader
+        headerClassStyle = {header}
+        title = "All Districts" />
+      < CreateDistrictTable 
+        header = {header}
+        tHead = {tHead} 
+        data = {districts} 
+        tRow = {tRow} 
+        striped = {striped} />
+    </div>
   );
 }
 

--- a/frontend/src/pages/Table/Program/ProgramDetail.js
+++ b/frontend/src/pages/Table/Program/ProgramDetail.js
@@ -8,7 +8,7 @@ import { getProgramDetail } from 'services/programServices';
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateGradeTable, CreateStudentTable, CreateCourseTable } from 'components/sharedStyles/Table/CreateTablesStyle';
-
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
 
 
 
@@ -47,17 +47,36 @@ function ProgramDetail(props) {
       <div>
           <Typography className={header} component="h1" variant="h4">{programName}</Typography>
 
-          < CreateGradeTable header = {header} title = "Grades"
-          tHead = {tHead} data = {gradeSet} tRow = {tRow} 
-          striped = {striped} />
 
-          < CreateCourseTable header = {header} title = "Course"
-          tHead = {tHead} data = {courseSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Grades" />
+          < CreateGradeTable 
+            header = {header} 
+            tHead = {tHead} 
+            data = {gradeSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateStudentTable header = {header} title = "Student"
-          tHead = {tHead} data = {studentSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Course" />
+          < CreateCourseTable 
+            header = {header} 
+            tHead = {tHead} 
+            data = {courseSet} 
+            tRow = {tRow} 
+            striped = {striped} />
+
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Student" />
+          < CreateStudentTable 
+            header = {header} 
+            tHead = {tHead} 
+            data = {studentSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
 
       </div>

--- a/frontend/src/pages/Table/Program/Programs.js
+++ b/frontend/src/pages/Table/Program/Programs.js
@@ -8,6 +8,8 @@ import { withStyles,
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateProgramTable } from 'components/sharedStyles/Table/CreateTablesStyle';
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
+
 
 
 function Programs(props) {
@@ -34,9 +36,17 @@ function Programs(props) {
 
 
   return (
-    < CreateProgramTable header = {header} title = 'All Programs' 
-    tHead = {tHead} data = {programs} tRow = {tRow} 
-    striped = {striped} />
+    <div>
+      <CreateTableHeader
+        headerClassStyle = {header}
+        title = "All Programs" />
+    < CreateProgramTable 
+      header = {header} 
+      tHead = {tHead} 
+      data = {programs} 
+      tRow = {tRow} 
+      striped = {striped} />
+    </div>
   );
 }
 

--- a/frontend/src/pages/Table/School/SchoolDetail.js
+++ b/frontend/src/pages/Table/School/SchoolDetail.js
@@ -10,7 +10,7 @@ import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateGradeTable, CreateAttendanceTable, CreateStudentTable, 
   CreateCourseTable, CreateBehaviorTable } from 'components/sharedStyles/Table/CreateTablesStyle';
-
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
 
 
 
@@ -54,25 +54,55 @@ function SchoolDetail(props) {
           <Typography className={header} component="h1" variant="h4">{schoolName}</Typography>
           <DetailLink k="District Name" val={districtName} link={`/district/${districtId}`} />
 
-          < CreateGradeTable header = {header} title = "Grades"
-          tHead = {tHead} data = {gradeSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Grades" />
+          < CreateGradeTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {gradeSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateAttendanceTable header = {header} title = "Attendance"
-          tHead = {tHead} data = {attendanceSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Attendance" />
+          < CreateAttendanceTable 
+            header = {header} 
+            tHead = {tHead} 
+            data = {attendanceSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateBehaviorTable header = {header} title = "Behavior"
-          tHead = {tHead} data = {behaviorSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Behavior" />
+          < CreateBehaviorTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {behaviorSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateCourseTable header = {header} title = "Course"
-          tHead = {tHead} data = {courseSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Course" />
+          < CreateCourseTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {courseSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateStudentTable header = {header} title = "Student"
-          tHead = {tHead} data = {studentSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {header}
+            title = "Student" />
+          < CreateStudentTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {studentSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
       </div>
   );

--- a/frontend/src/pages/Table/School/Schools.js
+++ b/frontend/src/pages/Table/School/Schools.js
@@ -8,6 +8,8 @@ import { withStyles,
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateSchoolTable } from 'components/sharedStyles/Table/CreateTablesStyle';
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
+
 
 
 function Schools(props) {
@@ -34,9 +36,17 @@ function Schools(props) {
 
 
   return (
-    < CreateSchoolTable header = {header} title = 'All Schools' 
-    tHead = {tHead} data = {schools} tRow = {tRow} 
-    striped = {striped} />
+    <div>
+      <CreateTableHeader
+          headerClassStyle = {header}
+          title = "All Schools" />
+      < CreateSchoolTable 
+        header = {header} 
+        tHead = {tHead} 
+        data = {schools} 
+        tRow = {tRow} 
+        striped = {striped} />
+    </div>
   );
 }
 

--- a/frontend/src/pages/Table/Student/StudentDetail.js
+++ b/frontend/src/pages/Table/Student/StudentDetail.js
@@ -9,7 +9,7 @@ import { DetailLink, DetailItem} from 'components/sharedStyles/Table/DetailStyle
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateGradeTable, CreateAttendanceTable, CreateBehaviorTable } from 'components/sharedStyles/Table/CreateTablesStyle';
-
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
 
 
 
@@ -20,7 +20,7 @@ function StudentDetail(props) {
   const studentIdParam = params;
   const {
     classes: {
-       striped, tHead, tRow,
+       striped, tHead, tRow,tableTitle
     },
   } = props;
 
@@ -64,18 +64,35 @@ function StudentDetail(props) {
           <DetailItem k="State Id" val={stateId} />
           <DetailLink k="School" val={school} link={`/school/${schoolId}`} />
           
+          <CreateTableHeader
+            headerClassStyle = {tableTitle}
+            title = "Grades" />
+          < CreateGradeTable 
+            header = {header}
+            tHead = {tHead} 
+            data = {gradeSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateGradeTable header = {header} title = "Grades"
-          tHead = {tHead} data = {gradeSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {tableTitle}
+            title = "Attendance" />
+          < CreateAttendanceTable 
+            headerClassStyle = {header}
+            tHead = {tHead} 
+            data = {attendanceSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
-          < CreateAttendanceTable header = {header} title = "Attendance"
-          tHead = {tHead} data = {attendanceSet} tRow = {tRow} 
-          striped = {striped} />
-
-          < CreateBehaviorTable header = {header} title = "Behavior"
-          tHead = {tHead} data = {behaviorSet} tRow = {tRow} 
-          striped = {striped} />
+          <CreateTableHeader
+            headerClassStyle = {tableTitle}
+            title = "Behavior" />
+          < CreateBehaviorTable 
+            header = {header} 
+            tHead = {tHead} 
+            data = {behaviorSet} 
+            tRow = {tRow} 
+            striped = {striped} />
 
 
 

--- a/frontend/src/pages/Table/Student/Students.js
+++ b/frontend/src/pages/Table/Student/Students.js
@@ -9,6 +9,8 @@ import {
 import { loadingJSX } from 'components/sharedStyles/LoadingStyles';
 import { TablePageStyles } from 'components/sharedStyles/Table/TablePageStyles';
 import { CreateStudentTable } from 'components/sharedStyles/Table/CreateTablesStyle';
+import CreateTableHeader from 'components/sharedStyles/Table/TableHeader';
+
 
 function Students(props) {
   const {
@@ -33,9 +35,17 @@ function Students(props) {
   }
 
   return (
-    < CreateStudentTable header = {header} title = 'All Students'
-    tHead = {tHead} data = {students} tRow = {tRow} 
-    striped = {striped} />
+    <div>
+      <CreateTableHeader
+          headerClassStyle = {header}
+          title = "All Students" />
+      < CreateStudentTable 
+        header = {header}
+        tHead = {tHead} 
+        data = {students} 
+        tRow = {tRow} 
+        striped = {striped} />
+    </div>
   );
 }
 


### PR DESCRIPTION
Pulling out the header component. Setting it up so we can have the design that is on the google drive. Also setting it up so we can have the tables appear based on the header being clicked on.

This isn't complete - I'm just trying to push smaller things earlier so I can get a heads up if this doesn't make sense. LMK