### PR TITLE
Updated Breadcrumb to Prevent Chaining Render

### DIFF
--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.js
@@ -23,23 +23,27 @@ function Breadcrumbs(props) {
   } = props;
   const routes = getRoutes(location.pathname);
 
+  const MapList = () => (
+    <nav className={nav}>
+      <ul className={list}>
+        {routes.map((x, i) => (
+          <Typography component="li" className={crumb} key={x.name}>
+            <Link
+              component={RouterLink}
+              color="primary"
+              to={x.route}
+            >
+              {x.name}
+            </Link>
+            {i !== routes.length - 1 && <span className={spacer}>{'>'}</span>}
+          </Typography>
+        ))}
+      </ul>
+    </nav>
+  );
+
   return (
-      <nav className={nav}>
-          <ul className={list}>
-              {routes.map((x, i) => (
-                  <Typography component="li" className={crumb} key={x.name}>
-                      <Link
-                        component={RouterLink}
-                        color="primary"
-                        to={x.route}
-                      >
-                          {x.name}
-                      </Link>
-                      {i !== routes.length - 1 && <span className={spacer}>{'>'}</span>}
-                  </Typography>
-              ))}
-          </ul>
-      </nav>
+    <MapList />
   );
 }
 

--- a/frontend/src/components/LeftNav.js
+++ b/frontend/src/components/LeftNav.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import {
   List, ListItem, ListItemIcon, ListItemText, withStyles,
 } from '@material-ui/core';
@@ -14,22 +13,22 @@ const navItems = [
   {
     name: 'My Students',
     icon: <UserGroup />,
-    route: 'student',
+    route: '/student',
   },
   {
     name: 'Visualize',
     icon: <ViewShow />,
-    route: 'visualize',
+    route: '/visualize',
   },
   {
     name: 'Analyze Data',
     icon: <Radar />,
-    route: 'analyze-data',
+    route: '/analyze-data',
   },
   {
     name: 'Manage Data',
     icon: <Wrench />,
-    route: 'manage-data',
+    route: '/manage-data',
   },
 ];
 


### PR DESCRIPTION
Up to this point, the breadcrumb has not been refreshing to correctly match the
url. As a consequence, links would quickly concatonate, one after the other, in
the following fashion: Student > Student > Student > Student > 1.

To stop this, I simply pulled the JSX into a constant that will
update whenever the router changes. Although you will still be greeted by
'Student > Student' if you click on the 'My Students' tab, this is now a
consquence of the routing arrangement, which needs needs some TLC of its own.

Going forward, we will likely want to render Proper nouns such as School and
Student names in the Breadcrumb instead of primary keys. For all I know, that
was the original purpose of the Breadcrumb issue- unfortunately I was not
present to hear the why of its posting. Because we will want continue using
primary keys in the url, a solution would likely entail accessing state from
within the BreadCrumb component to swap the primary key with it's correspondant
Proper Noun whenever a number is encountered in the url.

Sounds like a Brenden job!